### PR TITLE
Update RGBToVideo.cs

### DIFF
--- a/Assets/FFmpegUnityBind2/Code/Data/Commands/RGBToVideo.cs
+++ b/Assets/FFmpegUnityBind2/Code/Data/Commands/RGBToVideo.cs
@@ -61,7 +61,7 @@ namespace FFmpegUnityBind2
                 .Append(SPACE)
                 .Append(FPS_INSTRUCTION)
                 .Append(SPACE)
-                .Append(fps)
+                .Append(fps.ToString(System.Globalization.CultureInfo.InvariantCulture))
                 .Append(SPACE)
                 .Append(PIXEL_FORMAT_INSTRUCTION)
                 .Append(SPACE)
@@ -90,7 +90,7 @@ namespace FFmpegUnityBind2
                     .Append(SPACE)
                     .Append(TIME_INSTRUCTION)
                     .Append(SPACE)
-                    .Append(totalTime);
+                    .Append(totalTime.ToString(System.Globalization.CultureInfo.InvariantCulture));
             }
 
             //Output Video params


### PR DESCRIPTION
Update to persistently use dot '1.23' format for printing float values. Otherwise ffmpeg may not receive valid float numbers '1,23', which occurs on some `CultureInfo`s.