### PR TITLE
fix for android build fail

### DIFF
--- a/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Assets/Plugins/Android/mainTemplate.gradle
@@ -33,6 +33,7 @@ android {
     }
 
     aaptOptions {
+        noCompress = ['.unity3d', '.ress', '.resource', '.obb', '.bundle', '.unityexp'] + unityStreamingAssets.tokenize(', ')
         ignoreAssetsPattern = "!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~"
     }**PACKAGING_OPTIONS**
 }**REPOSITORIES****SOURCE_BUILD_SETUP**


### PR DESCRIPTION
Hi
Thank you for making such a great package.
It's very useful.

I tried to fix the build failure due to conflict of latest aapt options for android as below.

unity 2022.3.37f1

build err
```
UnityException: Error
mainTemplate.gradle file is using the old aaptOptions noCompress property definition which does not include types defined by unityStreamingAssets constant.
```